### PR TITLE
feat: update master s3 object atomically

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -480,7 +480,7 @@ def main(config):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Miner script')    
     parser.add_argument('--name', type=str, default=None, help='Optional miner name')
-    parser.add_argument('--netuid', type=int, default=220, help='Bittensor network UID.')
+    parser.add_argument('--netuid', type=int, default=212, help='Bittensor network UID.')
     parser.add_argument('--bucket', type=str, default='decis', help='S3 bucket name')
     parser.add_argument('--actual_batch_size', type=int, default=8, help='Training batch size per accumulation.')
     parser.add_argument('--device', type=str, default='cuda', help='Device to use for training (e.g., cpu or cuda)')

--- a/miner.py
+++ b/miner.py
@@ -323,9 +323,11 @@ def main(config):
             if config.use_wandb: wandb.log({"avg_masks_per_mask_wid": avg_masks_per_mask_wid})
 
             # Print completion
+            # del mask_filenames_per_mask_wid
+            # torch.cuda.empty_cache()
+            print(f'\tDownloading masks for blocks: {all_sync_blocks} and mask_wids: {mask_filenames_per_mask_wid.keys()} in {time.time() - full_sync_start_time} seconds')
             del mask_filenames_per_mask_wid
             torch.cuda.empty_cache()
-            print(f'\tDownloading masks for blocks: {all_sync_blocks} and mask_wids: {mask_filenames_per_mask_wid.keys()} in {time.time() - full_sync_start_time} seconds')
             # Get the pages for this block and my_uid.
             # This is global and deterministic
             n_pages = max(1, int(hparams.desired_batch_size * 0.01))
@@ -478,7 +480,7 @@ def main(config):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Miner script')    
     parser.add_argument('--name', type=str, default=None, help='Optional miner name')
-    parser.add_argument('--netuid', type=int, default=212, help='Bittensor network UID.')
+    parser.add_argument('--netuid', type=int, default=220, help='Bittensor network UID.')
     parser.add_argument('--bucket', type=str, default='decis', help='S3 bucket name')
     parser.add_argument('--actual_batch_size', type=int, default=8, help='Training batch size per accumulation.')
     parser.add_argument('--device', type=str, default='cuda', help='Device to use for training (e.g., cpu or cuda)')

--- a/start.sh
+++ b/start.sh
@@ -19,15 +19,15 @@
 echo " Create wallets if not existent"
 for name in Alice Bob Charlie Dave Eve Ferdie
 do
-echo "import bittensor as bt
+    echo "import bittensor as bt
 w = bt.wallet(name='Alice', hotkey='$name')
 if not w.coldkey_file.exists_on_device():
     w.create_coldkey_from_uri('//Alice', overwrite=True, use_password=False, suppress=True)
 if not w.hotkey_file.exists_on_device():
-    w.create_coldkey_from_uri('/$name', overwrite=True, use_password=False, suppress=False)
-" > create_wallet.py
-python3 create_wallet.py
-rm create_wallet.py
+    w.create_hotkey_from_uri('/$name', overwrite=True, use_password=False, suppress=False)
+    " > create_wallet.py
+    python3 create_wallet.py
+    rm create_wallet.py
 done
 
 # Close down all previous processes and restart them.
@@ -40,7 +40,7 @@ python3 tools/clean.py --bucket $BUCKET
 
 # Start all the processes again.
 pm2 start validator.py --interpreter python3 --name V1 -- --wallet.name Alice --wallet.hotkey Alice --bucket $BUCKET --device cuda:0 --use_wandb --restart
-pm2 start miner.py --interpreter python3 --name M1 -- --wallet.name Alice --wallet.hotkey Bob --bucket $BUCKET --device cuda:1 --use_wandb 
+pm2 start miner.py --interpreter python3 --name M1 -- --wallet.name Alice --wallet.hotkey Bob --bucket $BUCKET --device cuda:1 --use_wandb
 pm2 start miner.py --interpreter python3 --name M2 -- --wallet.name Alice --wallet.hotkey Charlie --bucket $BUCKET --device cuda:2 --use_wandb
 pm2 start miner.py --interpreter python3 --name M3 -- --wallet.name Alice --wallet.hotkey Dave --bucket $BUCKET --device cuda:3 --use_wandb
 pm2 start miner.py --interpreter python3 --name M4 -- --wallet.name Alice --wallet.hotkey Eve --bucket $BUCKET --device cuda:5 --use_wandb

--- a/validator.py
+++ b/validator.py
@@ -462,9 +462,9 @@ def main(config):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Validator script')
     parser.add_argument('--name', type=str, default=None, help='Optional name')
-    parser.add_argument('--bucket', type=str, default='aladdinformalised', help='S3 bucket name')
+    parser.add_argument('--bucket', type=str, default='decis', help='S3 bucket name')
     parser.add_argument('--batch_size', type=int, default=4, help='Batch size for eval.')
-    parser.add_argument('--netuid', type=int, default=220, help='Bittensor network uid.')
+    parser.add_argument('--netuid', type=int, default=212, help='Bittensor network uid.')
     parser.add_argument('--device', type=str, default='cuda', help='Device to use for training (e.g., cpu or cuda)')
     parser.add_argument('--use_wandb', action='store_true', help='Use Weights and Biases for logging')
     parser.add_argument('--restart', action='store_true', help='Restart all evaluation history')


### PR DESCRIPTION
## Description

### Issue Overview

Miners have been intermittently experiencing `AccessDenied` errors when attempting to download the master model from the validator's S3 bucket. The error message observed is:

```
No master:An error occurred (AccessDenied) when calling the GetObject operation: Access Denied Waiting .
```

This issue occurs sporadically and seems to be linked to the validator frequently updating the master model in S3. The problem is suspected to be due to race conditions or inconsistent Access Control List (ACL) settings during the upload process.

This contributes a significant overhead to the miners during the epoch sync

### Root Cause Analysis

- **Race Condition During Uploads:**
  - When the validator uploads the master model to S3, there is a window where the object may not be fully uploaded or the ACL permissions are not yet properly set.
  - Miners attempting to download the master model during this window encounter `AccessDenied` errors because the object is either incomplete or lacks the correct permissions.

- **Frequent Updates:**
  - The validator frequently updates the master model, increasing the likelihood of miners hitting this window of inconsistency.

### Solution Implemented

To resolve the issue, we have modified the validator's upload process to use **atomic uploads**. This ensures that the master model is always in a consistent state and that miners have the necessary permissions to access it.

The key steps implemented are:

1. **Upload to a Temporary Key:**
   - The validator uploads the master model to a temporary object with a unique key generated using `uuid.uuid4()`.
   - This prevents interference with the existing master model and ensures that miners can continue accessing the old model until the new one is fully uploaded and ready.

2. **Set ACLs Immediately:**
   - The ACL for the temporary object is set to `'public-read'` immediately after the upload.
   - This ensures that the object has the correct permissions as soon as it exists in S3.

3. **Atomic Copy to Master Key:**
   - The temporary object is atomically copied to the master key (official filename).
   - Using `CLIENT.copy_object` ensures that the master key always points to a fully uploaded and consistent version of the master model.
   - ACLs are set to `'public-read'` during this copy to maintain the correct permissions.

4. **Delete Temporary Object:**
   - After the atomic copy, the temporary object is deleted.
   - This cleans up the S3 bucket and avoids clutter from unused temporary files.
